### PR TITLE
Fix mailto: without pipe

### DIFF
--- a/slack/utility.go
+++ b/slack/utility.go
@@ -29,9 +29,13 @@ func (sc *Client) unSlackify(str string) string {
 		// if we do not have a match, just return the ID.
 		return str[1 : len(str)-1]
 	}
-	// Mail addresses e.g. <mailto:foo@bar.com|foo@bar.com>
+	// Mail addresses e.g. <mailto:foo@bar.com|foo@bar.com>, <mailto:test@example.org>
 	if strings.HasPrefix(str, "<mailto:") {
-		return str[8:strings.IndexRune(str, '|')]
+		endpos := strings.IndexRune(str, '|')
+		if endpos != -1 {
+			return str[8:endpos]
+		}
+		return str[8 : len(str)-1]
 	}
 	// Channels <#C02A2A2A2>
 	if strings.HasPrefix(str, "<#C") {

--- a/slack/utility_test.go
+++ b/slack/utility_test.go
@@ -19,9 +19,14 @@ func TestUnslackify(t *testing.T) {
 	raw3 := "<fooBarBaz &lt; &gt;>"
 	want3 := "<fooBarBaz < >>"
 
+	// contains mailto with and without pipe
+	raw4 := "<mailto:test@example.org|test-mailto> <mailto:nopipe@example.org>"
+	want4 := "test@example.org nopipe@example.org"
+
 	got1 := html.UnescapeString(bracketRe.ReplaceAllStringFunc(raw1, sc.unSlackify))
 	got2 := html.UnescapeString(bracketRe.ReplaceAllStringFunc(raw2, sc.unSlackify))
 	got3 := html.UnescapeString(bracketRe.ReplaceAllStringFunc(raw3, sc.unSlackify))
+	got4 := html.UnescapeString(bracketRe.ReplaceAllStringFunc(raw4, sc.unSlackify))
 
 	if got1 != want1 {
 		t.Log("Unslackify failed:")
@@ -38,9 +43,15 @@ func TestUnslackify(t *testing.T) {
 	}
 	if got3 != want3 {
 		t.Log("Unslackify failed:")
-		t.Logf("Got: %v", got2)
-		t.Logf("Want: %v", want2)
+		t.Logf("Got: %v", got3)
+		t.Logf("Want: %v", want3)
 		t.Fail()
 	}
 
+	if got4 != want4 {
+		t.Log("Unslackify failed:")
+		t.Logf("Got: %v", got4)
+		t.Logf("Want: %v", want4)
+		t.Fail()
+	}
 }


### PR DESCRIPTION
Currently, I'm stripping the mailto: prefix as is done with http:// (and was required for the existing test cases). We could change this by starting at index 1 instead of 8, but I'm not sure what's best.